### PR TITLE
Timestamp counter updates

### DIFF
--- a/nixie/backend.py
+++ b/nixie/backend.py
@@ -1,4 +1,4 @@
-import uuid, collections
+import uuid, collections, time
 
 class Backend(collections.MutableMapping):
   """Dict-like storage for counters"""
@@ -7,17 +7,24 @@ class Backend(collections.MutableMapping):
     key = uuid.uuid4().hex
     if key in self.store:
       raise ValueError('key collision')
-    self.store[key] = 0
+    self.__setitem__(key, 0)
     return key
+
+  def get(self, key):
+    return self.store[key]
 
   def __init__(self):
     self.store = dict()
 
   def __getitem__(self, key):
-    return self.store[key]
+    (_, val) = self.store[key]
+    return val
 
   def __setitem__(self, key, value):
-    self.store[key] = int(value)
+    ts = int(time.time())
+    val = int(value)
+    self.store[key] = (ts, val)
+    return val
 
   def __delitem__(self, key):
     del self.store[key]

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -1,4 +1,4 @@
-import unittest, uuid
+import unittest, time
 from nixie.backend import Backend
 
 class BackendTestCase(unittest.TestCase):
@@ -15,11 +15,29 @@ class BackendTestCase(unittest.TestCase):
   def test_read(self):
     self.assertEqual(self.be[self.key], 0)
 
+  def test_get(self):
+    (ts, val) = self.be.get(self.key)
+    now = int(time.time())
+    self.assertLessEqual(ts, now)
+    self.assertGreaterEqual(1, now - ts)
+    self.assertEqual(val, 0)
+
   def test_update(self):
     self.be[self.key] = 12
     self.assertEqual(self.be[self.key], 12)
     self.be[self.key] = 24
     self.assertEqual(self.be[self.key], 24)
+
+  def test_update_timestamped(self):
+    self.be[self.key] = 12
+    (ts1, val1) = self.be.get(self.key)
+    self.assertLessEqual(ts1, int(time.time()))
+    self.assertEqual(val1, 12)
+    time.sleep(1)
+    self.be[self.key] = 24
+    (ts2, val2) = self.be.get(self.key)
+    self.assertGreater(ts2, ts1)
+    self.assertEqual(val2, 24)
 
   def test_in(self):
     self.assertTrue(self.key in self.be)


### PR DESCRIPTION
All updates internally timestamped (localtime, 1 sec resolution). New backend's method `get` returns counter with timestamp.