### PR TITLE
Bump fastapi to 0.92.0

### DIFF
--- a/integration/basic.hurl
+++ b/integration/basic.hurl
@@ -21,7 +21,7 @@ header "Content-Type" not exists
 header "Nixie-Step" == "1"
 header "Nixie-Name" not exists
 header "Nixie-Description" not exists
-``````
+``
 
 # read counter
 GET http://127.0.0.1:7312/{{key}}
@@ -32,7 +32,7 @@ header "Content-Type" contains "text/plain"
 header "Nixie-Step" == "1"
 header "Nixie-Name" not exists
 header "Nixie-Description" not exists
-```0```
+`0`
 
 
 # update counter
@@ -44,7 +44,7 @@ header "Content-Type" contains "text/plain"
 header "Nixie-Step" == "1"
 header "Nixie-Name" not exists
 header "Nixie-Description" not exists
-```1```
+`1`
 
 
 # update counter again
@@ -56,7 +56,7 @@ header "Content-Type" contains "text/plain"
 header "Nixie-Step" == "1"
 header "Nixie-Name" not exists
 header "Nixie-Description" not exists
-```2```
+`2`
 
 
 # delete counter

--- a/integration/complex.hurl
+++ b/integration/complex.hurl
@@ -26,7 +26,7 @@ header "Content-Type" not exists
 header "Nixie-Step" == "4"
 header "Nixie-Name" == "Quoter"
 header "Nixie-Description" == "A counter with step 4"
-``````
+``
 
 
 # read counter
@@ -38,7 +38,7 @@ header "Content-Type" contains "text/plain"
 header "Nixie-Step" == "4"
 header "Nixie-Name" == "Quoter"
 header "Nixie-Description" == "A counter with step 4"
-```3```
+`3`
 
 
 # update counter
@@ -50,7 +50,7 @@ header "Content-Type" contains "text/plain"
 header "Nixie-Step" == "4"
 header "Nixie-Name" == "Quoter"
 header "Nixie-Description" == "A counter with step 4"
-```7```
+`7`
 
 
 # patch counter
@@ -67,7 +67,7 @@ header "Content-Type" not exists
 header "Nixie-Step" == "5"
 header "Nixie-Name" == "Quiter"
 header "Nixie-Description" == "A counter with step 5"
-``````
+``
 
 
 # update counter again
@@ -79,7 +79,7 @@ header "Content-Type" contains "text/plain"
 header "Nixie-Step" == "5"
 header "Nixie-Name" == "Quiter"
 header "Nixie-Description" == "A counter with step 5"
-```12```
+`12`
 
 
 # delete counter

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,9 +4,11 @@ certifi==2022.12.7
 charset-normalizer==2.1.0
 click==8.1.3
 coverage==6.4.2
-fastapi==0.79.0
+fastapi==0.92.0
 h11==0.13.0
+httpcore==0.16.3
 httptools==0.4.0
+httpx==0.23.3
 idna==3.3
 iniconfig==1.1.1
 nanoid==2.0.0
@@ -20,8 +22,9 @@ pytest-cov==3.0.0
 python-dotenv==0.20.0
 PyYAML==6.0
 requests==2.28.1
+rfc3986==1.5.0
 sniffio==1.2.0
-starlette==0.19.1
+starlette==0.25.0
 tomli==2.0.1
 typing_extensions==4.3.0
 urllib3==1.26.11

--- a/tests/test_frontend.py
+++ b/tests/test_frontend.py
@@ -47,7 +47,7 @@ class FrontendTestCase(unittest.TestCase):
       'nixie-name': 'custom counter',
       'nixie-description': 'this is a custom counter'
     }
-    resp = self.client.post('/', data='3', headers=headers)
+    resp = self.client.post('/', content=b'3', headers=headers)
     self.assertEqual(resp.status_code, 201)
     self.assertTrue(resp.headers['Content-Type'].startswith('text/plain'))
     self.assertEqual(resp.headers['Nixie-Step'], '3')
@@ -73,7 +73,7 @@ class FrontendTestCase(unittest.TestCase):
     self.assertEqual(resp.text.encode(), b'6')
 
   def test_create_custom_invalid(self):
-    resp = self.client.post('/', data='3', headers={'nixie-step': 'a'})
+    resp = self.client.post('/', content=b'3', headers={'nixie-step': 'a'})
     self.assertEqual(resp.status_code, 422)
     self.assertIn('value is not a valid integer', resp.json()['detail'][0]['msg'])
 


### PR DESCRIPTION
- Bump `fastapi` and `starlette`
- Explicitly add `httpx` for tests
- Fix tests for `httpx` deprecation
- Fix integration tests for `hurl` v2 body capture style deprecation 