### PR TITLE
Bump pytest to 7.2.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ certifi==2022.12.7
 charset-normalizer==2.1.0
 click==8.1.3
 coverage==6.4.2
+exceptiongroup==1.1.0
 fastapi==0.92.0
 h11==0.13.0
 httpcore==0.16.3
@@ -17,7 +18,7 @@ pluggy==1.0.0
 py==1.11.0
 pydantic==1.9.1
 pyparsing==3.0.9
-pytest==7.1.2
+pytest==7.2.1
 pytest-cov==3.0.0
 python-dotenv==0.20.0
 PyYAML==6.0


### PR DESCRIPTION
Apparently there is a sec alert on old pytest. Don't think the attack vector is applicable, but updating just in case.